### PR TITLE
Fix backend install script path

### DIFF
--- a/backend/install.sh
+++ b/backend/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-uv venv
-source ./venv/bin/activate
+uv venv .venv
+source ./.venv/bin/activate
 uv pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- fix `backend/install.sh` to source `.venv`

## Testing
- `make install-backend`
- `make install-frontend` *(fails: Node.js write EPIPE)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc0ea564832393c3c7f902f66326