### PR TITLE
Add basic tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,50 @@
+import sys
+import types
+import os
+import pytest
+
+# Ensure project root is in path
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, 'backend'))
+
+# Stub for databutton package
+class Secrets:
+    def __init__(self):
+        self._data = {}
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+    def set(self, key, value):
+        self._data[key] = value
+
+class JsonStore(dict):
+    def get(self, key, default=None):
+        if key not in self:
+            raise FileNotFoundError
+        return super().get(key, default)
+    def put(self, key, value):
+        self[key] = value
+
+class Storage:
+    def __init__(self):
+        self.json = JsonStore()
+
+_db = types.SimpleNamespace(secrets=Secrets(), storage=Storage())
+sys.modules.setdefault('databutton', _db)
+
+from backend.main import create_app
+from databutton_app.mw.auth_mw import get_authorized_user
+
+@pytest.fixture
+def app():
+    cwd = os.getcwd()
+    os.chdir(os.path.join(ROOT_DIR, 'backend'))
+    application = create_app()
+    os.chdir(cwd)
+    application.dependency_overrides[get_authorized_user] = lambda: {'sub': 'testuser'}
+    return application
+
+@pytest.fixture
+def client(app):
+    from fastapi.testclient import TestClient
+    return TestClient(app)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,48 @@
+import jwt
+from backend.app.apis.a2a import AgentInfo, A2AMessage
+
+JWT_SECRET = "nexusforge_default_secret"
+
+
+def make_token():
+    return jwt.encode({"sub": "testuser"}, JWT_SECRET, algorithm="HS256")
+
+
+def auth_headers():
+    return {"Authorization": f"Bearer {make_token()}"}
+
+
+def test_verify_token(client):
+    resp = client.get("/routes/auth/verify-token", headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["user_id"] == "testuser"
+
+
+def test_supabase_config(client):
+    import databutton
+    databutton.secrets.set("SUPABASE_ANON_KEY", "anon")
+    resp = client.get("/routes/supabase-config", headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["anon_key"] == "anon"
+
+
+def test_a2a_send(client):
+    message = A2AMessage(
+        from_agent=AgentInfo(agent_id="a1"),
+        to_agent=AgentInfo(agent_id="a2"),
+        message_type="text",
+        content={"text": "hello"},
+    )
+    resp = client.post("/routes/a2a/send", json=message.model_dump(), headers=auth_headers())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert "message_id" in data
+
+
+def test_agents_status(client):
+    resp = client.get("/routes/orchestrator/agents/status", headers=auth_headers())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "agents" in data
+    assert isinstance(data["agents"], list)

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  globals: { 'ts-jest': { useESM: true } },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^components/(.*)$': '<rootDir>/src/components/$1'
+  }
+};

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@11labs/react": "0.0.4",
@@ -300,11 +301,16 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
+    "@firebase/app": "^0.11.1",
     "@sentry/react": "7.101.1",
     "@sentry/types": "7.101.1",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.4.3",
     "@types/amplitude-js": "^8",
     "@types/file-saver": "^2",
     "@types/firebase": "^3.2.1",
+    "@types/jest": "^29.5.12",
     "@types/leaflet": "1.9.14",
     "@types/lodash": "^4",
     "@types/mapbox-gl": "2.7.20",
@@ -325,6 +331,7 @@
     "@types/recordrtc": "^5",
     "@types/three": "^0",
     "@types/vinyl-fs": "^3",
+    "@vitejs/plugin-react": "^4.0.0",
     "@vitejs/plugin-react-swc": "3.3.2",
     "autoprefixer": "^10.4.20",
     "dotenv": "16.4.5",
@@ -332,19 +339,24 @@
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-react-refresh": "0.4.3",
+    "jest": "^29.7.0",
     "openapi-types": "12.1.3",
     "postcss": "^8.4.45",
     "raw-body": "2.5.2",
     "tailwindcss": "^3.4.10",
+    "ts-jest": "^29.1.1",
     "ts-prune": "0.10.3",
     "type-fest": "4.6.0",
     "typescript": "5.2.2",
     "typescript-language-server": "4.3.2",
     "vite": "4.4.5",
-    "vite-tsconfig-paths": "4.2.2",
-    "@vitejs/plugin-react": "^4.0.0",
-    "@firebase/app": "^0.11.1"
+    "vite-tsconfig-paths": "4.2.2"
   },
   "packageManager": "yarn@4.0.2",
-  "nodeLinker": "pnpm"
+  "nodeLinker": "pnpm",
+  "description": "This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.",
+  "main": "postcss.config.js",
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
 }

--- a/frontend/src/components/__tests__/ChatInterface.test.tsx
+++ b/frontend/src/components/__tests__/ChatInterface.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ChatInterface } from '../ChatInterface';
+
+const messages = [
+  { id: '1', content: 'Hi', sender: 'user', timestamp: new Date() }
+];
+
+test('renders initial messages', () => {
+  render(
+    <MemoryRouter>
+      <ChatInterface initialMessages={messages} />
+    </MemoryRouter>
+  );
+  expect(screen.getByText('Hi')).toBeInTheDocument();
+});

--- a/frontend/src/components/__tests__/InputArea.test.tsx
+++ b/frontend/src/components/__tests__/InputArea.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InputArea } from '../InputArea';
+
+test('sends message on submit', async () => {
+  const onSend = jest.fn();
+  render(<InputArea onSendMessage={onSend} />);
+  const input = screen.getByPlaceholderText(/type a message/i);
+  await userEvent.type(input, 'hello');
+  await userEvent.keyboard('{Enter}');
+  expect(onSend).toHaveBeenCalledWith('hello');
+});


### PR DESCRIPTION
## Summary
- add pytest fixtures and API tests
- create React component tests with jest and testing-library
- configure jest for ts-jest and setup testing utilities
- update frontend package.json with test script and dev dependencies

## Testing
- `pytest -q`
- `npx jest` *(fails: Cannot find module 'p-try')*

------
https://chatgpt.com/codex/tasks/task_e_6843fc17656c8323b9c65e3063c28330