### PR TITLE
Add packaging evaluation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ make run-frontend
 The backend server runs on port 8000 and the frontend development server runs on port 5173. The frontend Vite server proxies API requests to the backend on port 8000.
 
 Visit <http://localhost:5173> to view the application.
+
+## Packaging options
+
+See [docs/packaging.md](docs/packaging.md) for an overview of potential approaches to distribute this application on desktop and mobile platforms.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,17 @@
+# Packaging Evaluation
+
+This document outlines options for distributing the application on desktop and mobile platforms.
+
+## Desktop: Electron vs Tauri
+
+- **Electron** wraps a Chromium browser with Node.js. It is mature, widely adopted, and integrates easily with existing web applications. However, its binaries tend to be large and memory usage is higher.
+- **Tauri** uses system webviews and a Rust backend. It yields smaller downloads and better performance but introduces a Rust toolchain and may require more configuration.
+
+Either option can host the current frontend built with Vite. Electron offers greater ecosystem familiarity, while Tauri may deliver a lighter footprint.
+
+## Mobile: React Native vs PWA
+
+- **React Native** allows reuse of some React components but requires adapting them to React Native primitives. Shared business logic can stay in TypeScript, but UI code will need adjustments.
+- **Progressive Web App (PWA)** transforms the existing web codebase into an installable application. Implementing service workers and responsive design can provide an app-like experience without rewriting the UI.
+
+Given the React + TypeScript frontend, starting with a PWA is the simplest path to mobile. If native capabilities or store distribution become necessary, exploring a React Native rewrite is feasible.


### PR DESCRIPTION
## Summary
- add a docs folder with `packaging.md`
- reference packaging options in README

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6843fc384cf883239be720d14d9dad96