### PR TITLE
Add architecture overview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ make run-frontend
 The backend server runs on port 8000 and the frontend development server runs on port 5173. The frontend Vite server proxies API requests to the backend on port 8000.
 
 Visit <http://localhost:5173> to view the application.
+
+## Arquitectura
+
+Para una descripción general de los módulos principales (Auth, Orchestrator, A2A
+ y agentes especializados) consulta [docs/architecture.md](docs/architecture.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,24 @@
+# Arquitectura de NexusForge
+
+La plataforma se compone de un backend en **FastAPI** y un frontend en **React**. El backend expone varios módulos que se comunican mediante peticiones HTTP y almacenamiento compartido. A continuación se describe el flujo principal entre los módulos.
+
+```
+[Frontend]
+    |
+    v
+[Auth] <-- validación de tokens y emisión de JWT
+    |
+    v
+[Orchestrator] --(mensajes A2A)--> [Agentes especializados]
+    |
+    v
+[Frontend]
+```
+
+- **Auth**: gestiona la validación de tokens externos (por ejemplo, de Supabase) y genera tokens internos JWT para el resto de endpoints.
+- **Orchestrator**: es el agente maestro. Recibe las consultas de los usuarios y decide a qué agente especializado dirigirlas. Mantiene contexto de sesión y registra el agente usado.
+- **A2A (Agent to Agent)**: define un protocolo de mensajería entre agentes. Permite almacenar conversaciones, histórico y metadatos para cada interacción.
+- **Agentes especializados**: módulos futuros que implementarán la lógica para entrenamiento, nutrición, recuperación, etc. Actualmente el orquestador simula sus respuestas.
+- **Config**: expone la configuración necesaria para el frontend, como las credenciales de Supabase.
+
+El objetivo final de **NexusForge** es ofrecer una plataforma SaaS con IA que integre diversos agentes expertos (entrenamiento, nutrición, biometría, entre otros) coordinados por un orquestador. Esto permitirá a los usuarios recibir planes y recomendaciones personalizadas desde una única interfaz.


### PR DESCRIPTION
## Summary
- document high-level architecture and goal
- link to docs from README

## Testing
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc4dae7c83239c416fd42b936629