### PR TITLE
Remove unused json imports from backend

### DIFF
--- a/backend/app/apis/a2a/__init__.py
+++ b/backend/app/apis/a2a/__init__.py
@@ -4,7 +4,6 @@ from typing import Dict, Any, Optional, List, Union
 import uuid
 from datetime import datetime
 import databutton as db
-import json
 from app.apis.auth import get_current_user
 
 router = APIRouter(prefix="/a2a", tags=["a2a"])

--- a/backend/app/apis/orchestrator/__init__.py
+++ b/backend/app/apis/orchestrator/__init__.py
@@ -4,7 +4,6 @@ from typing import Dict, Any, Optional, List, Union
 import uuid
 from datetime import datetime
 import databutton as db
-import json
 from app.apis.auth import get_current_user
 from app.apis.a2a import A2AMessage, AgentInfo
 


### PR DESCRIPTION
## Summary
- remove unused `json` imports from a2a and orchestrator API modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452cdb75948323aaef882dd9714349