### PR TITLE
Parameterize Supabase URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Antes de ejecutar la aplicación es necesario definir algunas variables de entor
 
 - `JWT_SECRET`: clave utilizada para firmar los tokens generados por el backend.
 - `SUPABASE_ANON_KEY`: clave anónima de Supabase que el backend expone al frontend.
+- `SUPABASE_URL`: URL base de Supabase utilizada por el backend.
 - `DATABUTTON_PROJECT_ID`: opcional, identifica el proyecto Databutton para la compilación.
 - `DATABUTTON_EXTENSIONS`: opcional, lista de extensiones Databutton en formato JSON.
 - `DATABUTTON_SERVICE_TYPE`: define si el backend se ejecuta en modo `development` o `production`.

--- a/backend/app/apis/config/__init__.py
+++ b/backend/app/apis/config/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+import os
 import databutton as db
 
 router = APIRouter()
@@ -15,7 +16,7 @@ def get_supabase_config() -> SupabaseConfigResponse:
     """Obtiene la configuración de Supabase para el frontend"""
     try:
         # URL de Supabase proporcionada por el usuario
-        supabase_url = "https://blrzviguanblulnxepnx.supabase.co"
+        supabase_url = os.getenv("SUPABASE_URL", "https://blrzviguanblulnxepnx.supabase.co")
         
         # Obtener la clave anónima desde los secretos
         supabase_anon_key = db.secrets.get("SUPABASE_ANON_KEY")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ ipykernel==6.29.5
 fastapi==0.111.0
 python-multipart==0.0.9
 uvicorn[standard]==0.29.0
+python-dotenv
 
 openai
 beautifulsoup4

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,6 @@ La plataforma se compone de un backend en **FastAPI** y un frontend en **React**
 - **Orchestrator**: es el agente maestro. Recibe las consultas de los usuarios y decide a qué agente especializado dirigirlas. Mantiene contexto de sesión y registra el agente usado.
 - **A2A (Agent to Agent)**: define un protocolo de mensajería entre agentes. Permite almacenar conversaciones, histórico y metadatos para cada interacción.
 - **Agentes especializados**: módulos futuros que implementarán la lógica para entrenamiento, nutrición, recuperación, etc. Actualmente el orquestador simula sus respuestas.
-- **Config**: expone la configuración necesaria para el frontend, como las credenciales de Supabase.
+- **Config**: expone la configuración necesaria para el frontend, como las credenciales de Supabase. La URL de Supabase se define mediante la variable de entorno `SUPABASE_URL`.
 
 El objetivo final de **NexusForge** es ofrecer una plataforma SaaS con IA que integre diversos agentes expertos (entrenamiento, nutrición, biometría, entre otros) coordinados por un orquestador. Esto permitirá a los usuarios recibir planes y recomendaciones personalizadas desde una única interfaz.


### PR DESCRIPTION
## Summary
- use `SUPABASE_URL` environment variable for config API
- note new `SUPABASE_URL` variable in docs
- include python-dotenv in backend requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452cdd6b688323a36f01b439e32adc